### PR TITLE
[sensor]テーブル名がハードコーディングされているのでファイルに抽出する

### DIFF
--- a/sensor/config.ini
+++ b/sensor/config.ini
@@ -4,3 +4,4 @@ port = 3306
 user = root
 password = password
 database = sensors
+table = sensors


### PR DESCRIPTION
テーブル名がハードコーディングされていたのでコンフィグでの変更を可能にした
- クエリの形は決まっているためあらかじめクエリを作成しておく際にテーブル名を挿入する